### PR TITLE
discard evaluation with SIGINT fully implemented

### DIFF
--- a/RobotController/learning/rlpower_algorithm.py
+++ b/RobotController/learning/rlpower_algorithm.py
@@ -51,32 +51,51 @@ class RLPowerAlgorithm:
                     for y in range(self.NUM_SERVOS)])
         self.controller = RLPowerController(self._current_spline)
 
-    def next_evaluation(self, light_sensor_value=0):
-        logging.info("current spline size: {}".format(self._current_spline_size))
-        movement_fitness = self.get_current_fitness()
-        light_fitness = self._light_fitness_weight * light_sensor_value
-        current_fitness = movement_fitness + light_fitness
-        logging.info("Last evaluation fitness: {} (movement: {} + light: {})".format(current_fitness, movement_fitness, light_fitness))
-        logging.info("Current position: {}".format(self._fitness_querier.get_position()))
-        self.save_in_ranking(current_fitness, self._current_spline)
-        self._current_evaluation += 1
-        if math.floor((self._end_spline_size - self._initial_spline_size)/self._number_of_fitness_evaluations *
-                              self._current_evaluation) + 3 > self._current_spline_size:
-            self._current_spline_size += 1
-            self._current_spline = self.recalculate_spline(self._current_spline, self._current_spline_size)
-            for number, (fitness, rspline) in enumerate(self.ranking):
-                self.ranking[number] = _RankingEntry((fitness, self.recalculate_spline(rspline, self._current_spline_size)))
-        # Add random noise to the spline
-        uniform = np.array(
-            [[random.normalvariate(0, self._sigma) for x in range(self._current_spline_size)]
-             for y in range(self.NUM_SERVOS)])
+    def _generate_spline(self):
         # Add a weighted average of the best splines seen so far
         total = self.epsilon  # something similar to 0, but not 0 ( division by 0 is evil )
         modifier = np.zeros(self._current_spline.shape)
         for (fitness, spline) in self.ranking:
             total += fitness
             modifier += (spline - self._current_spline) * fitness
-        self._current_spline = self._current_spline + uniform + modifier / total
+
+        # random noise for the spline
+        noise = np.array(
+            [[random.normalvariate(0, self._sigma) for x in range(self._current_spline_size)]
+             for y in range(self.NUM_SERVOS)])
+
+        return self._current_spline + noise + modifier / total
+
+    def skip_evaluation(self):
+        logging.info("Skipping evaluation, starting new one")
+        self._current_spline = self._generate_spline()
+        self.controller.set_spline(self._current_spline)
+        self._fitness_querier.start()
+
+    def next_evaluation(self, light_sensor_value=0):
+        self._current_evaluation += 1
+        logging.info("current spline size: {}".format(self._current_spline_size))
+
+        # generate fitness
+        movement_fitness = self.get_current_fitness()
+        light_fitness = self._light_fitness_weight * light_sensor_value
+        current_fitness = movement_fitness + light_fitness
+        logging.info("Last evaluation fitness: {} (movement: {} + light: {})".format(current_fitness, movement_fitness, light_fitness))
+        logging.info("Current position: {}".format(self._fitness_querier.get_position()))
+
+        # save old evaluation
+        self.save_in_ranking(current_fitness, self._current_spline)
+
+        # check if is time to increase the number of evaluations
+        if math.floor((self._end_spline_size - self._initial_spline_size)/self._number_of_fitness_evaluations *
+                              self._current_evaluation) + 3 > self._current_spline_size:
+            self._current_spline_size += 1
+            self._current_spline = self.recalculate_spline(self._current_spline, self._current_spline_size)
+            for number, (fitness, rspline) in enumerate(self.ranking):
+                self.ranking[number] = _RankingEntry((fitness, self.recalculate_spline(rspline, self._current_spline_size)))
+
+        # update values
+        self._current_spline = self._generate_spline()
         self.controller.set_spline(self._current_spline)
         self._sigma *= self._sigma_decay
         self._save_runtime_data_to_file(self._runtime_data_file)

--- a/RobotController/main.py
+++ b/RobotController/main.py
@@ -21,11 +21,11 @@ def noop_interrupt_handler(signum, frame):
 def interrupt_handler(signum, frame):
     signal.signal(signal.SIGINT, noop_interrupt_handler)
     logging.info("changing evaluation")
-    controller.stop_current_evaluation()
     command = input(INTERRUPT_MESSAGE + "\n")
     if command == 'q':
         controller.suicide()
         #sys.exit(0)
+    controller.stop_current_evaluation()
     signal.signal(signal.SIGINT, interrupt_handler)
 
 

--- a/RobotController/robot_brain.py
+++ b/RobotController/robot_brain.py
@@ -61,13 +61,16 @@ class RobotBrain:
         Check if is a moment for a new evaluation and starts a new one
         :param force: forces the new evaluation to start
         """
-        self.HAL.led.setColor(self.HAL.led._magenta)
         current_check = time.time()
         light_level = 1 + (self.HAL.sensor.readADC(0) / -255)
         if force or current_check > self._next_check:
+            self.HAL.led.setColor(self.HAL.led._magenta)
             logging.info("next movement values current {}, next {}".format(current_check, self._next_check))
-            self.algorithm.next_evaluation(1 + (self.HAL.sensor.readADC(0) / -255))  # 255-0 to 0-1
-            # TODO make HAL smarter in light readings
+            if force:
+                # TODO make HAL smarter in light readings
+                self.algorithm.next_evaluation(1 + (self.HAL.sensor.readADC(0) / -255))  # 255-0 to 0-1
+            else:
+                self.algorithm.skip_evaluation()
             self._next_check = current_check + self.TIME_CHECK_TIMEOUT
         if light_level < self.LIGHT_THRESHOLD:
             self.HAL.led.setColor(self.HAL.led._green)
@@ -83,7 +86,6 @@ class RobotBrain:
         intended to do an emergency stop for a bad controller that could "kill" the robot
         """
         # self.HAL.off()
-        # TODO discard current evaluation
         self._check_next_evaluation(force=True)
 
     def _die(self):


### PR DESCRIPTION
- when SIGINT (ctrl-c) is received, the current evaluation is discarded and a quit "prompt" is shown
  (before the evaluation was evaluated and possibly saved)
- stop_current_evaluation moved after input, so that the 30 seconds start properly
